### PR TITLE
[Feat] 캘린더 위에 RaisedView올리기 구현

### DIFF
--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AccountBook/CategorySelect/CategorySelectTableViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AccountBook/CategorySelect/CategorySelectTableViewController.swift
@@ -16,16 +16,27 @@ class CategorySelectTableViewController: UITableViewController {
 
   // 기본 카테고리는 수정이 되면 안됨
   private var defaultCategory = [
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.foodIcon2.image, titleText: "식비"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.shoppingIcon2.image, titleText: "쇼핑"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.fashionIcon2.image, titleText: "패션"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.cultureIcon2.image, titleText: "문화생활"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.trafficIcon2.image, titleText: "교통"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.cafeIcon2.image, titleText: "카페"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.playIcon2.image, titleText: "유흥"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.eventIcon2.image, titleText: "경조사"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.regularPaymentIcon2.image, titleText: "정기결제"),
-    DefaultCategory(iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.etcIcon2.image, titleText: "기타"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.foodIcon2.image, titleText: "식비"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.shoppingIcon2.image, titleText: "쇼핑"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.fashionIcon2.image, titleText: "패션"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.cultureIcon2.image, titleText: "문화생활"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.trafficIcon2.image, titleText: "교통"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.cafeIcon2.image, titleText: "카페"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.playIcon2.image, titleText: "유흥"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.eventIcon2.image, titleText: "경조사"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.regularPaymentIcon2.image,
+      titleText: "정기결제"),
+    DefaultCategory(
+      iconImage: BudgetBuddiesAsset.AppImage.CategoryIcon.etcIcon2.image, titleText: "기타"),
   ]
 
   // 기본 카테고리를 제거할 수 없도록 설정한 코드

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AccountBook/CategorySelect/DefaultCategory.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AccountBook/CategorySelect/DefaultCategory.swift
@@ -10,6 +10,6 @@ import UIKit
 
 // 여기에서 사용하는 데이터 모델 파일의 폴더 위치 구조는 변경해야 함
 struct DefaultCategory {
-  let iconImage : UIImage
-  let titleText : String
+  let iconImage: UIImage
+  let titleText: String
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/BottomSheet/Controllers/BottomSheetViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/BottomSheet/Controllers/BottomSheetViewController.swift
@@ -161,6 +161,7 @@ final class BottomSheetViewController: DimmedViewController {
   }
 }
 
+// MARK: - UITextField Delegate
 extension BottomSheetViewController: UITextFieldDelegate {
   // 입력 시작
   func textFieldDidBeginEditing(_ textField: UITextField) {
@@ -171,4 +172,8 @@ extension BottomSheetViewController: UITextFieldDelegate {
   func textFieldDidEndEditing(_ textField: UITextField) {
     print("입력 끝")
   }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        self.view.endEditing(true)
+    }
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/BottomSheet/Controllers/BottomSheetViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/BottomSheet/Controllers/BottomSheetViewController.swift
@@ -172,8 +172,8 @@ extension BottomSheetViewController: UITextFieldDelegate {
   func textFieldDidEndEditing(_ textField: UITextField) {
     print("입력 끝")
   }
-    
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        self.view.endEditing(true)
-    }
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    self.view.endEditing(true)
+  }
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
@@ -37,7 +37,7 @@ final class CalendarViewController: UIViewController {
 
   // MARK: - Set up Data
   private func setupData() {
-    self.calendarModel = YearMonth(year: 2024, month: 7) // 현재 달로 바꾸기
+    self.calendarModel = YearMonth(year: 2024, month: 7)  // 현재 달로 바꾸기
   }
 
   // MARK: - Set up NavigationBar
@@ -104,7 +104,7 @@ extension CalendarViewController: UITableViewDataSource {
       if let calendarModel = calendarModel {
         mainCalendarCell.ymModel = calendarModel
         mainCalendarCell.isSixWeek = calendarModel.isSixWeeksLong()
-          // 여기서 나중에 특정월에있는 할인지원정보들 fetch해서 보내기
+        // 여기서 나중에 특정월에있는 할인지원정보들 fetch해서 보내기
       }
 
       mainCalendarCell.delegate = self

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
@@ -247,7 +247,7 @@ extension CalendarViewController: MainCalendarCellDelegate {
 extension CalendarViewController: InfoTitleWithButtonCellDelegate {
   // infoTitleWithButtonCell: 전체보기 버튼 눌리는 시점
   func didTapShowDetailViewButton(
-    in cell: InfoTitleWithButtonCell, infoType: InfoTitleWithButtonCell.InfoType
+    in cell: InfoTitleWithButtonCell, infoType: InfoType
   ) {
 
     let vc: UIViewController

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
@@ -37,7 +37,7 @@ final class CalendarViewController: UIViewController {
 
   // MARK: - Set up Data
   private func setupData() {
-    self.calendarModel = YearMonth(year: 2024, month: 7)
+    self.calendarModel = YearMonth(year: 2024, month: 7) // 현재 달로 바꾸기
   }
 
   // MARK: - Set up NavigationBar
@@ -104,6 +104,7 @@ extension CalendarViewController: UITableViewDataSource {
       if let calendarModel = calendarModel {
         mainCalendarCell.ymModel = calendarModel
         mainCalendarCell.isSixWeek = calendarModel.isSixWeeksLong()
+          // 여기서 나중에 특정월에있는 할인지원정보들 fetch해서 보내기
       }
 
       mainCalendarCell.delegate = self

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/CustomInfoColor.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/CustomInfoColor.swift
@@ -10,12 +10,12 @@ import UIKit
 
 class CustomInfoColor: UIView {
 
-//  enum InfoType {
-//    case discount
-//    case support
-//  }
-    
-    var infoType: InfoType
+  //  enum InfoType {
+  //    case discount
+  //    case support
+  //  }
+
+  var infoType: InfoType
 
   // MARK: - Properties
   let colorView: UIView = {
@@ -43,7 +43,7 @@ class CustomInfoColor: UIView {
 
   // MARK: - override init
   init(infoType: InfoType) {
-      self.infoType = infoType
+    self.infoType = infoType
     super.init(frame: .zero)
 
     switch infoType {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/CustomInfoColor.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/CustomInfoColor.swift
@@ -10,10 +10,12 @@ import UIKit
 
 class CustomInfoColor: UIView {
 
-  enum InfoType {
-    case discount
-    case support
-  }
+//  enum InfoType {
+//    case discount
+//    case support
+//  }
+    
+    var infoType: InfoType
 
   // MARK: - Properties
   let colorView: UIView = {
@@ -41,6 +43,7 @@ class CustomInfoColor: UIView {
 
   // MARK: - override init
   init(infoType: InfoType) {
+      self.infoType = infoType
     super.init(frame: .zero)
 
     switch infoType {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InfoTitleWithButtonCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InfoTitleWithButtonCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol InfoTitleWithButtonCellDelegate: AnyObject {
   func didTapShowDetailViewButton(
-    in cell: InfoTitleWithButtonCell, infoType: InfoTitleWithButtonCell.InfoType)
+    in cell: InfoTitleWithButtonCell, infoType: InfoType)
 }
 
 class InfoTitleWithButtonCell: UITableViewCell {
@@ -19,10 +19,13 @@ class InfoTitleWithButtonCell: UITableViewCell {
 
   weak var delegate: InfoTitleWithButtonCellDelegate?
 
-  enum InfoType {
-    case discount
-    case support
-  }
+//  enum InfoType {
+//    case discount
+//    case support
+//  }
+    
+    var infoType: InfoType?
+    
 
   // 최근 타입을 저장하기 위한 변수
   var currentInfoType: InfoType?
@@ -85,6 +88,7 @@ class InfoTitleWithButtonCell: UITableViewCell {
 
   // MARK: - Configure
   func configure(infoType: InfoType) {
+      self.infoType = infoType
     self.currentInfoType = infoType
 
     switch infoType {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InfoTitleWithButtonCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InfoTitleWithButtonCell.swift
@@ -19,13 +19,12 @@ class InfoTitleWithButtonCell: UITableViewCell {
 
   weak var delegate: InfoTitleWithButtonCellDelegate?
 
-//  enum InfoType {
-//    case discount
-//    case support
-//  }
-    
-    var infoType: InfoType?
-    
+  //  enum InfoType {
+  //    case discount
+  //    case support
+  //  }
+
+  var infoType: InfoType?
 
   // 최근 타입을 저장하기 위한 변수
   var currentInfoType: InfoType?
@@ -88,7 +87,7 @@ class InfoTitleWithButtonCell: UITableViewCell {
 
   // MARK: - Configure
   func configure(infoType: InfoType) {
-      self.infoType = infoType
+    self.infoType = infoType
     self.currentInfoType = infoType
 
     switch infoType {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InformationCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InformationCell.swift
@@ -21,10 +21,12 @@ class InformationCell: UITableViewCell {
   // 임시 링크 (모델에 타이틀, 기간, 할인률, 링크 다 가지고 있을 거임)
   var urlString: String = ""
 
-  enum InfoType {
-    case discount
-    case support
-  }
+//  enum InfoType {
+//    case discount
+//    case support
+//  }
+    
+    var infoType: InfoType?
 
   var likesToggle: Bool = false
   var likes: Int = 0
@@ -200,6 +202,7 @@ class InformationCell: UITableViewCell {
 
   // MARK: - Configure
   func configure(infoType: InfoType) {
+      self.infoType = infoType
     // 기존 arragedSubviews제거
     for view in verticalStackView.arrangedSubviews {
       verticalStackView.removeArrangedSubview(view)

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InformationCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/InformationCell.swift
@@ -21,12 +21,12 @@ class InformationCell: UITableViewCell {
   // 임시 링크 (모델에 타이틀, 기간, 할인률, 링크 다 가지고 있을 거임)
   var urlString: String = ""
 
-//  enum InfoType {
-//    case discount
-//    case support
-//  }
-    
-    var infoType: InfoType?
+  //  enum InfoType {
+  //    case discount
+  //    case support
+  //  }
+
+  var infoType: InfoType?
 
   var likesToggle: Bool = false
   var likes: Int = 0
@@ -202,7 +202,7 @@ class InformationCell: UITableViewCell {
 
   // MARK: - Configure
   func configure(infoType: InfoType) {
-      self.infoType = infoType
+    self.infoType = infoType
     // 기존 arragedSubviews제거
     for view in verticalStackView.arrangedSubviews {
       verticalStackView.removeArrangedSubview(view)

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
@@ -41,6 +41,9 @@ class MainCalendarCell: UITableViewCell {
       reSetupBackViewConstraints()
     }
   }
+    
+    // 임시로 만들
+    var myInfoModel: InfoModel? = InfoModel(title: "지그재그 썸머 세일", startDate: "2024-07-07", endDate: "2024-07-12")
 
   // UI Components
   // MARK: - 뒷 배경
@@ -119,8 +122,8 @@ class MainCalendarCell: UITableViewCell {
   // MARK: - 뒷 배경 margin 뷰
   var backViewMargin: UIView = {
     let view = UIView()
-      view.layer.borderColor = UIColor.red.cgColor
-      view.layer.borderWidth = 1.0
+//      view.layer.borderColor = UIColor.red.cgColor
+//      view.layer.borderWidth = 1.0
     return view
   }()
 
@@ -180,8 +183,8 @@ class MainCalendarCell: UITableViewCell {
     let numberOfDays = calendar.range(of: .day, in: .month, for: firstOfMonth)!.count  // 달에 몇일까지 있는지 (28, 30, 31...)
 
     var weeks: [[Int]] = Array(repeating: Array(repeating: 0, count: daysInWeek), count: 6)
-    //        var dayCounter = 1
-    var numberOfWeeks = 0
+//            var dayCounter = 1
+//    var numberOfWeeks = 0
 
     // 날짜 레이블 추가
     for i in 0..<totalCells {  // 42개 셀
@@ -234,18 +237,27 @@ class MainCalendarCell: UITableViewCell {
     //        }
       
       // RaisedView 올리기
-      setupRaisedViews()
+      guard let myInfoModel = myInfoModel else { return }
+      setupRaisedViews(myInfoModel)
   }
     
     // MARK: - Set up RaisedViews
-    private func setupRaisedViews() {
+    private func setupRaisedViews(_ infoModel: InfoModel) {
+        
+        let widthInt = Int(backViewMargin.frame.width / 7) // 7일로 나눔
+        
+        guard let startDatePosition = infoModel.startDatePosition() else { return } // .row: 0 = 1번줄 .colum: 0 = 1번째
+        guard let endDatePosition = infoModel.endDatePosition() else { return } // 0 = 1번째
+        // 얘를 들어 지금 7월 7일이 2번째 줄 1번째 위치라고 하면
+        
+        // 기간이 한줄에 걸친 기간이라면...
         let raisedView = RaisedInfoView()
         backViewMargin.addSubview(raisedView)
         raisedView.snp.makeConstraints { make in
-            make.top.equalTo(headerStackView.snp.bottom).inset(-40 - 80) // 정확한 수치는 나중에 계산..
-            make.leading.equalToSuperview().inset(0)
+            make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
+            make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
+            make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
             make.height.equalTo(17)
-            make.width.equalTo((backViewMargin.frame.width/7) * 4)
         }
     }
 

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
@@ -43,6 +43,7 @@ class MainCalendarCell: UITableViewCell {
   }
     
     // 임시로 만들
+    // 추후에 didSet을 통해 특정 월에 맞는 정보들만 받게끔 구현할 예정
     var infoModels: [InfoModel] = [
         InfoModel(title: "캘린더 너무 어려워요", startDate: "2024-07-02", endDate: "2024-07-05", infoType: .support),
         InfoModel(title: "하지만 해야지", startDate: "2024-07-07", endDate: "2024-07-10", infoType: .discount),

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
@@ -46,7 +46,7 @@ class MainCalendarCell: UITableViewCell {
   // MARK: - 뒷 배경
   var backView: UIView = {
     let view = UIView()
-    view.backgroundColor = .white
+      view.backgroundColor = BudgetBuddiesAsset.AppColor.white.color
     view.layer.cornerRadius = 15
 
     view.layer.shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.1).cgColor
@@ -119,6 +119,8 @@ class MainCalendarCell: UITableViewCell {
   // MARK: - 뒷 배경 margin 뷰
   var backViewMargin: UIView = {
     let view = UIView()
+      view.layer.borderColor = UIColor.red.cgColor
+      view.layer.borderWidth = 1.0
     return view
   }()
 
@@ -230,7 +232,22 @@ class MainCalendarCell: UITableViewCell {
     //        if numberOfWeeks > 5 {
     //            print("\(year)년 \(month)월은 6줄 이상")
     //        }
+      
+      // RaisedView 올리기
+      setupRaisedViews()
   }
+    
+    // MARK: - Set up RaisedViews
+    private func setupRaisedViews() {
+        let raisedView = RaisedInfoView()
+        backViewMargin.addSubview(raisedView)
+        raisedView.snp.makeConstraints { make in
+            make.top.equalTo(headerStackView.snp.bottom).inset(-40 - 80) // 정확한 수치는 나중에 계산..
+            make.leading.equalToSuperview().inset(0)
+            make.height.equalTo(17)
+            make.width.equalTo((backViewMargin.frame.width/7) * 4)
+        }
+    }
 
   // MARK: - Set up UI
   private func setupUI() {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
@@ -43,7 +43,7 @@ class MainCalendarCell: UITableViewCell {
   }
     
     // 임시로 만들
-    var myInfoModel: InfoModel? = InfoModel(title: "지그재그 썸머 세일", startDate: "2024-07-07", endDate: "2024-07-12")
+    var myInfoModel: InfoModel? = InfoModel(title: "지그재그 썸머 세일", startDate: "2024-07-17", endDate: "2024-07-31")
 
   // UI Components
   // MARK: - 뒷 배경
@@ -250,15 +250,60 @@ class MainCalendarCell: UITableViewCell {
         guard let endDatePosition = infoModel.endDatePosition() else { return } // 0 = 1번째
         // 얘를 들어 지금 7월 7일이 2번째 줄 1번째 위치라고 하면
         
-        // 기간이 한줄에 걸친 기간이라면...
-        let raisedView = RaisedInfoView()
-        backViewMargin.addSubview(raisedView)
-        raisedView.snp.makeConstraints { make in
-            make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
-            make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
-            make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
-            make.height.equalTo(17)
+        guard let numberOfRows = infoModel.numberOfRows() else { return }
+        
+        if numberOfRows == 1 {
+            // 한 줄에 걸쳐있으면 하나만 생성
+            let raisedView = RaisedInfoView()
+            backViewMargin.addSubview(raisedView)
+            raisedView.snp.makeConstraints { make in
+                make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
+                make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
+                make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
+                make.height.equalTo(17)
+            }
+            
+        } else {
+            print("일정이\(numberOfRows)줄에 걸쳐있습니다.")
+            let firstRaisedView = RaisedInfoView()
+            backViewMargin.addSubview(firstRaisedView)
+            firstRaisedView.snp.makeConstraints { make in
+                make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
+                make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
+//                make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
+                make.trailing.equalToSuperview().inset(0)
+                make.height.equalTo(17)
+            }
+            
+            // 중간 뷰 그리기
+            if numberOfRows >= 3 {
+                print("3줄 이상인 뷰")
+                for i in 1..<numberOfRows - 1 {
+                    let middleRaisedView = RaisedInfoView()
+                    backViewMargin.addSubview(middleRaisedView)
+                    middleRaisedView.snp.makeConstraints { make in
+                        make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row + i))) // -40 기본, 80기준으로 한칸위아래
+                        make.leading.trailing.equalToSuperview().inset(0)
+                    }
+                }
+                
+            }
+            
+            let lastRaisedView = RaisedInfoView()
+            backViewMargin.addSubview(lastRaisedView)
+            lastRaisedView.snp.makeConstraints { make in
+                make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row + numberOfRows - 1))) // -40 기본, 80기준으로 한칸위아래
+//                make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
+                make.leading.equalToSuperview().inset(0)
+                make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
+//                make.trailing.equalToSuperview().inset(0)
+                make.height.equalTo(17)
+            }
         }
+        // 두 줄 이상에 걸쳐있으면
+        // leading은 그대로, trailng은 inset 0 (첫줄)
+        // 중간에는 leading, trailng inset 0 (만약 세 줄 이상이면 중간 줄)
+        // trailng은 그대로, leading은 inset 0 (마지막)
     }
 
   // MARK: - Set up UI

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
@@ -43,7 +43,7 @@ class MainCalendarCell: UITableViewCell {
   }
     
     // 임시로 만들
-    var myInfoModel: InfoModel? = InfoModel(title: "지그재그 썸머 세일", startDate: "2024-07-17", endDate: "2024-07-31", infoType: .discount)
+    var myInfoModel: InfoModel? = InfoModel(title: "캘린더 너무 어려워요", startDate: "2024-07-17", endDate: "2024-07-31", infoType: .support)
 
   // UI Components
   // MARK: - 뒷 배경
@@ -232,19 +232,19 @@ class MainCalendarCell: UITableViewCell {
     // MARK: - Set up RaisedViews
     private func setupRaisedViews(_ infoModel: InfoModel) {
         let infoType = infoModel.infoType
-        
+        guard let title = infoModel.title else { return }
+        guard let startDatePosition = infoModel.startDatePosition() else { return } // .row: 0 = 1번줄 .column: 0 = 1번째
+        guard let endDatePosition = infoModel.endDatePosition() else { return } // 0 = 1번째
         
         let widthInt = Int(backViewMargin.frame.width / 7) // 7일로 나눔
         
-        guard let startDatePosition = infoModel.startDatePosition() else { return } // .row: 0 = 1번줄 .column: 0 = 1번째
-        guard let endDatePosition = infoModel.endDatePosition() else { return } // 0 = 1번째
         // 얘를 들어 지금 7월 7일이 2번째 줄 1번째 위치라고 하면
         
         guard let numberOfRows = infoModel.numberOfRows() else { return }
         
         if numberOfRows == 1 {
             // 한 줄에 걸쳐있으면 하나만 생성
-            let raisedView = RaisedInfoView(infoType: infoType)
+            let raisedView = RaisedInfoView(title: title, infoType: infoType)
             backViewMargin.addSubview(raisedView)
             raisedView.snp.makeConstraints { make in
                 make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
@@ -254,7 +254,7 @@ class MainCalendarCell: UITableViewCell {
             }
             
         } else {
-            let firstRaisedView = RaisedInfoView(infoType: infoType)
+            let firstRaisedView = RaisedInfoView(title: title, infoType: infoType)
             backViewMargin.addSubview(firstRaisedView)
             firstRaisedView.snp.makeConstraints { make in
                 make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
@@ -267,7 +267,7 @@ class MainCalendarCell: UITableViewCell {
             // 중간 뷰 그리기
             if numberOfRows >= 3 {
                 for i in 1..<numberOfRows - 1 {
-                    let middleRaisedView = RaisedInfoView(infoType: infoType)
+                    let middleRaisedView = RaisedInfoView(title: title, infoType: infoType)
                     backViewMargin.addSubview(middleRaisedView)
                     middleRaisedView.snp.makeConstraints { make in
                         make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row + i))) // -40 기본, 80기준으로 한칸위아래
@@ -277,7 +277,7 @@ class MainCalendarCell: UITableViewCell {
                 
             }
             
-            let lastRaisedView = RaisedInfoView(infoType: infoType)
+            let lastRaisedView = RaisedInfoView(title: title, infoType: infoType)
             backViewMargin.addSubview(lastRaisedView)
             lastRaisedView.snp.makeConstraints { make in
                 make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row + numberOfRows - 1))) // -40 기본, 80기준으로 한칸위아래

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
@@ -43,7 +43,7 @@ class MainCalendarCell: UITableViewCell {
   }
     
     // 임시로 만들
-    var myInfoModel: InfoModel? = InfoModel(title: "지그재그 썸머 세일", startDate: "2024-07-17", endDate: "2024-07-31")
+    var myInfoModel: InfoModel? = InfoModel(title: "지그재그 썸머 세일", startDate: "2024-07-17", endDate: "2024-07-31", infoType: .discount)
 
   // UI Components
   // MARK: - 뒷 배경
@@ -224,18 +224,6 @@ class MainCalendarCell: UITableViewCell {
       }
     }
 
-    //        // 주 수 계산
-    //        for week in weeks {
-    //            if week.contains(where: { $0 != 0 }) {
-    //                numberOfWeeks += 1
-    //            }
-    //        }
-    //
-    //        // 6주 이상 출력되는 달을 감지하여 출력
-    //        if numberOfWeeks > 5 {
-    //            print("\(year)년 \(month)월은 6줄 이상")
-    //        }
-      
       // RaisedView 올리기
       guard let myInfoModel = myInfoModel else { return }
       setupRaisedViews(myInfoModel)
@@ -243,10 +231,12 @@ class MainCalendarCell: UITableViewCell {
     
     // MARK: - Set up RaisedViews
     private func setupRaisedViews(_ infoModel: InfoModel) {
+        let infoType = infoModel.infoType
+        
         
         let widthInt = Int(backViewMargin.frame.width / 7) // 7일로 나눔
         
-        guard let startDatePosition = infoModel.startDatePosition() else { return } // .row: 0 = 1번줄 .colum: 0 = 1번째
+        guard let startDatePosition = infoModel.startDatePosition() else { return } // .row: 0 = 1번줄 .column: 0 = 1번째
         guard let endDatePosition = infoModel.endDatePosition() else { return } // 0 = 1번째
         // 얘를 들어 지금 7월 7일이 2번째 줄 1번째 위치라고 하면
         
@@ -254,7 +244,7 @@ class MainCalendarCell: UITableViewCell {
         
         if numberOfRows == 1 {
             // 한 줄에 걸쳐있으면 하나만 생성
-            let raisedView = RaisedInfoView()
+            let raisedView = RaisedInfoView(infoType: infoType)
             backViewMargin.addSubview(raisedView)
             raisedView.snp.makeConstraints { make in
                 make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
@@ -264,8 +254,7 @@ class MainCalendarCell: UITableViewCell {
             }
             
         } else {
-            print("일정이\(numberOfRows)줄에 걸쳐있습니다.")
-            let firstRaisedView = RaisedInfoView()
+            let firstRaisedView = RaisedInfoView(infoType: infoType)
             backViewMargin.addSubview(firstRaisedView)
             firstRaisedView.snp.makeConstraints { make in
                 make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row))) // -40 기본, 80기준으로 한칸위아래
@@ -277,9 +266,8 @@ class MainCalendarCell: UITableViewCell {
             
             // 중간 뷰 그리기
             if numberOfRows >= 3 {
-                print("3줄 이상인 뷰")
                 for i in 1..<numberOfRows - 1 {
-                    let middleRaisedView = RaisedInfoView()
+                    let middleRaisedView = RaisedInfoView(infoType: infoType)
                     backViewMargin.addSubview(middleRaisedView)
                     middleRaisedView.snp.makeConstraints { make in
                         make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row + i))) // -40 기본, 80기준으로 한칸위아래
@@ -289,7 +277,7 @@ class MainCalendarCell: UITableViewCell {
                 
             }
             
-            let lastRaisedView = RaisedInfoView()
+            let lastRaisedView = RaisedInfoView(infoType: infoType)
             backViewMargin.addSubview(lastRaisedView)
             lastRaisedView.snp.makeConstraints { make in
                 make.top.equalTo(headerStackView.snp.bottom).inset(-40 - (80 * (startDatePosition.row + numberOfRows - 1))) // -40 기본, 80기준으로 한칸위아래

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/MainCalendarCell.swift
@@ -41,22 +41,25 @@ class MainCalendarCell: UITableViewCell {
       reSetupBackViewConstraints()
     }
   }
-    
-    // 임시로 만들
-    // 추후에 didSet을 통해 특정 월에 맞는 정보들만 받게끔 구현할 예정
-    var infoModels: [InfoModel] = [
-        InfoModel(title: "캘린더 너무 어려워요", startDate: "2024-07-02", endDate: "2024-07-05", infoType: .support),
-        InfoModel(title: "하지만 해야지", startDate: "2024-07-07", endDate: "2024-07-10", infoType: .discount),
-        InfoModel(title: "국가장학금 나줘요", startDate: "2024-07-14", endDate: "2024-07-18", infoType: .support),
-        InfoModel(title: "어쩔거야", startDate: "2024-07-17", endDate: "2024-07-24", infoType: .discount),
-        InfoModel(title: "안녕하세요", startDate: "2024-07-23", endDate: "2024-07-30", infoType: .support)
-    ]
+
+  // 임시로 만들
+  // 추후에 didSet을 통해 특정 월에 맞는 정보들만 받게끔 구현할 예정
+  var infoModels: [InfoModel] = [
+    InfoModel(
+      title: "캘린더 너무 어려워요", startDate: "2024-07-02", endDate: "2024-07-05", infoType: .support),
+    InfoModel(
+      title: "하지만 해야지", startDate: "2024-07-07", endDate: "2024-07-10", infoType: .discount),
+    InfoModel(
+      title: "국가장학금 나줘요", startDate: "2024-07-14", endDate: "2024-07-18", infoType: .support),
+    InfoModel(title: "어쩔거야", startDate: "2024-07-17", endDate: "2024-07-24", infoType: .discount),
+    InfoModel(title: "안녕하세요", startDate: "2024-07-23", endDate: "2024-07-30", infoType: .support),
+  ]
 
   // UI Components
   // MARK: - 뒷 배경
   var backView: UIView = {
     let view = UIView()
-      view.backgroundColor = BudgetBuddiesAsset.AppColor.white.color
+    view.backgroundColor = BudgetBuddiesAsset.AppColor.white.color
     view.layer.cornerRadius = 15
 
     view.layer.shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.1).cgColor
@@ -129,8 +132,8 @@ class MainCalendarCell: UITableViewCell {
   // MARK: - 뒷 배경 margin 뷰
   var backViewMargin: UIView = {
     let view = UIView()
-//      view.layer.borderColor = UIColor.red.cgColor
-//      view.layer.borderWidth = 1.0
+    //      view.layer.borderColor = UIColor.red.cgColor
+    //      view.layer.borderWidth = 1.0
     return view
   }()
 
@@ -190,8 +193,8 @@ class MainCalendarCell: UITableViewCell {
     let numberOfDays = calendar.range(of: .day, in: .month, for: firstOfMonth)!.count  // 달에 몇일까지 있는지 (28, 30, 31...)
 
     var weeks: [[Int]] = Array(repeating: Array(repeating: 0, count: daysInWeek), count: 6)
-//            var dayCounter = 1
-//    var numberOfWeeks = 0
+    //            var dayCounter = 1
+    //    var numberOfWeeks = 0
 
     // 날짜 레이블 추가
     for i in 0..<totalCells {  // 42개 셀
@@ -231,163 +234,167 @@ class MainCalendarCell: UITableViewCell {
       }
     }
 
-      // raisedView 올리기
-      // 겹치는 일정인지 확인하기
-      // 추가 개발해야하는 거
-      // 3 일정이 연달아 겹치는 경우
-      for idx in 0..<infoModels.count {
-          let currentModel = infoModels[idx]
-          let currentStartDate = dateFromString(currentModel.startDate)
-          let currentEndDate = dateFromString(currentModel.endDate)
-          var isOverlapped = false
-          
-          for otherIdx in 0..<infoModels.count {
-              if idx == otherIdx { continue }
-              
-              let otherModel = infoModels[otherIdx]
-              let otherStartDate = dateFromString(otherModel.startDate)
-              let otherEndDate = dateFromString(otherModel.endDate)
-              
-              if let currentStart = currentStartDate, let currentEnd = currentEndDate, let otherStart = otherStartDate, let otherEnd = otherEndDate {
-                  if currentStart <= otherEnd && currentEnd >= otherStart {
-                      if currentStart > otherStart {
-                          isOverlapped = true
-                          break
-                      }
-                  }
-              }
+    // raisedView 올리기
+    // 겹치는 일정인지 확인하기
+    // 추가 개발해야하는 거
+    // 3 일정이 연달아 겹치는 경우
+    for idx in 0..<infoModels.count {
+      let currentModel = infoModels[idx]
+      let currentStartDate = dateFromString(currentModel.startDate)
+      let currentEndDate = dateFromString(currentModel.endDate)
+      var isOverlapped = false
+
+      for otherIdx in 0..<infoModels.count {
+        if idx == otherIdx { continue }
+
+        let otherModel = infoModels[otherIdx]
+        let otherStartDate = dateFromString(otherModel.startDate)
+        let otherEndDate = dateFromString(otherModel.endDate)
+
+        if let currentStart = currentStartDate, let currentEnd = currentEndDate,
+          let otherStart = otherStartDate, let otherEnd = otherEndDate
+        {
+          if currentStart <= otherEnd && currentEnd >= otherStart {
+            if currentStart > otherStart {
+              isOverlapped = true
+              break
+            }
           }
-          
-          setupRaisedViews(currentModel, isOverlapped: isOverlapped)
+        }
       }
+
+      setupRaisedViews(currentModel, isOverlapped: isOverlapped)
+    }
   }
-    func dateFromString(_ dateString: String?) -> Date? {
-        guard let dateString = dateString else { return nil }
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        return dateFormatter.date(from: dateString)
+  func dateFromString(_ dateString: String?) -> Date? {
+    guard let dateString = dateString else { return nil }
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    return dateFormatter.date(from: dateString)
+  }
+
+  // MARK: - Set up RaisedViews
+  private func setupRaisedViews(_ infoModel: InfoModel, isOverlapped: Bool) {
+    let infoType = infoModel.infoType
+    guard let title = infoModel.title else { return }
+    guard let startDatePosition = infoModel.startDatePosition() else { return }
+    guard let endDatePosition = infoModel.endDatePosition() else { return }
+    guard let numberOfRows = infoModel.numberOfRows() else { return }
+
+    let widthInt = Int(backViewMargin.frame.width / 7)
+    //        let topInsetBase = isOverlapped ? -61 : -40
+
+    func createRaisedView(topInsetBase: Int, row: Int, leadingInset: Int, trailingInset: Int)
+      -> RaisedInfoView
+    {
+      let raisedView = RaisedInfoView(title: title, infoType: infoType)
+      backViewMargin.addSubview(raisedView)
+      raisedView.snp.makeConstraints { make in
+        make.top.equalTo(headerStackView.snp.bottom).inset(topInsetBase - (80 * row))
+        make.leading.equalToSuperview().inset(leadingInset)
+        make.trailing.equalToSuperview().inset(trailingInset)
+        make.height.equalTo(17)
+      }
+      return raisedView
     }
-    
-    // MARK: - Set up RaisedViews
-    private func setupRaisedViews(_ infoModel: InfoModel, isOverlapped: Bool) {
-        let infoType = infoModel.infoType
-        guard let title = infoModel.title else { return }
-        guard let startDatePosition = infoModel.startDatePosition() else { return }
-        guard let endDatePosition = infoModel.endDatePosition() else { return }
-        guard let numberOfRows = infoModel.numberOfRows() else { return }
-        
-        let widthInt = Int(backViewMargin.frame.width / 7)
-//        let topInsetBase = isOverlapped ? -61 : -40
-        
-        func createRaisedView(topInsetBase: Int, row: Int, leadingInset: Int, trailingInset: Int) -> RaisedInfoView {
-            let raisedView = RaisedInfoView(title: title, infoType: infoType)
-            backViewMargin.addSubview(raisedView)
-            raisedView.snp.makeConstraints { make in
-                make.top.equalTo(headerStackView.snp.bottom).inset(topInsetBase - (80 * row))
-                make.leading.equalToSuperview().inset(leadingInset)
-                make.trailing.equalToSuperview().inset(trailingInset)
-                make.height.equalTo(17)
-            }
-            return raisedView
+
+    if numberOfRows == 1 {
+      _ = createRaisedView(
+        topInsetBase: isOverlapped ? -61 : -40,
+        row: startDatePosition.row,
+        leadingInset: widthInt * startDatePosition.column,
+        trailingInset: widthInt * (7 - endDatePosition.column - 1)
+      )
+    } else {
+      _ = createRaisedView(
+        topInsetBase: isOverlapped ? -61 : -40,
+        row: startDatePosition.row,
+        leadingInset: widthInt * startDatePosition.column,
+        trailingInset: 0
+      )
+      if numberOfRows >= 3 {
+        for i in 1..<numberOfRows - 1 {
+          _ = createRaisedView(
+            topInsetBase: -40,
+            row: startDatePosition.row + i,
+            leadingInset: 0,
+            trailingInset: 0
+          )
         }
-        
-        if numberOfRows == 1 {
-            _ = createRaisedView(
-                topInsetBase: isOverlapped ? -61 : -40,
-                row: startDatePosition.row,
-                leadingInset: widthInt * startDatePosition.column,
-                trailingInset: widthInt * (7 - endDatePosition.column - 1)
-            )
-        } else {
-            _ = createRaisedView(
-                topInsetBase: isOverlapped ? -61 : -40,
-                row: startDatePosition.row,
-                leadingInset: widthInt * startDatePosition.column,
-                trailingInset: 0
-            )
-            if numberOfRows >= 3 {
-                for i in 1..<numberOfRows - 1 {
-                    _ = createRaisedView(
-                        topInsetBase: -40,
-                        row: startDatePosition.row + i,
-                        leadingInset: 0,
-                        trailingInset: 0
-                    )
-                }
-            }
-            _ = createRaisedView(
-                topInsetBase: -40,
-                row: startDatePosition.row + numberOfRows - 1,
-                leadingInset: 0,
-                trailingInset: widthInt * (7 - endDatePosition.column - 1)
-            )
-        }
+      }
+      _ = createRaisedView(
+        topInsetBase: -40,
+        row: startDatePosition.row + numberOfRows - 1,
+        leadingInset: 0,
+        trailingInset: widthInt * (7 - endDatePosition.column - 1)
+      )
     }
-//    private func setupRaisedViews(_ infoModel: InfoModel, isOverLapped: Bool) {
-//        
-//        let infoType = infoModel.infoType
-//        guard let title = infoModel.title else { return }
-//        guard let startDatePosition = infoModel.startDatePosition() else { return } // .row: 0 = 1번줄 .column: 0 = 1번째
-//        guard let endDatePosition = infoModel.endDatePosition() else { return } // 0 = 1번째
-//        
-//        let widthInt = Int(backViewMargin.frame.width / 7) // 7일로 나눔
-//        
-//        // 얘를 들어 지금 7월 7일이 2번째 줄 1번째 위치라고 하면
-//        
-//        guard let numberOfRows = infoModel.numberOfRows() else { return }
-//        
-//        if numberOfRows == 1 {
-//            // 한 줄에 걸쳐있으면 하나만 생성
-//            let raisedView = RaisedInfoView(title: title, infoType: infoType)
-//            backViewMargin.addSubview(raisedView)
-//            raisedView.snp.makeConstraints { make in
-//                make.top.equalTo(headerStackView.snp.bottom).inset(
-//                    isOverLapped ? -61 - (80 * (startDatePosition.row)) : -40 - (80 * (startDatePosition.row))
-//                )
-//                make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
-//                make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
-//                make.height.equalTo(17)
-//            }
-//            
-//        } else {
-//            let firstRaisedView = RaisedInfoView(title: title, infoType: infoType)
-//            backViewMargin.addSubview(firstRaisedView)
-//            firstRaisedView.snp.makeConstraints { make in
-//                make.top.equalTo(headerStackView.snp.bottom).inset(
-//                    isOverLapped ? -61 - (80 * (startDatePosition.row)) : -40 - (80 * (startDatePosition.row))
-//                )
-//                make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
-//                make.trailing.equalToSuperview().inset(0)
-//                make.height.equalTo(17)
-//            }
-//            
-//            // 중간 뷰 그리기
-//            if numberOfRows >= 3 {
-//                for i in 1..<numberOfRows - 1 {
-//                    let middleRaisedView = RaisedInfoView(title: title, infoType: infoType)
-//                    backViewMargin.addSubview(middleRaisedView)
-//                    middleRaisedView.snp.makeConstraints { make in
-//                        make.top.equalTo(headerStackView.snp.bottom).inset(
-//                            isOverLapped ? -61 - (80 * (startDatePosition.row + i)) : -40 - (80 * (startDatePosition.row + i))
-//                        )
-//                        make.leading.trailing.equalToSuperview().inset(0)
-//                    }
-//                }
-//                
-//            }
-//            
-//            let lastRaisedView = RaisedInfoView(title: title, infoType: infoType)
-//            backViewMargin.addSubview(lastRaisedView)
-//            lastRaisedView.snp.makeConstraints { make in
-//                make.top.equalTo(headerStackView.snp.bottom).inset(
-//                    isOverLapped ? -61 - (80 * (startDatePosition.row - 1)) : -40 - (80 * (startDatePosition.row - 1))
-//                )
-//                make.leading.equalToSuperview().inset(0)
-//                make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
-//                make.height.equalTo(17)
-//            }
-//        }
-//    }
+  }
+  //    private func setupRaisedViews(_ infoModel: InfoModel, isOverLapped: Bool) {
+  //
+  //        let infoType = infoModel.infoType
+  //        guard let title = infoModel.title else { return }
+  //        guard let startDatePosition = infoModel.startDatePosition() else { return } // .row: 0 = 1번줄 .column: 0 = 1번째
+  //        guard let endDatePosition = infoModel.endDatePosition() else { return } // 0 = 1번째
+  //
+  //        let widthInt = Int(backViewMargin.frame.width / 7) // 7일로 나눔
+  //
+  //        // 얘를 들어 지금 7월 7일이 2번째 줄 1번째 위치라고 하면
+  //
+  //        guard let numberOfRows = infoModel.numberOfRows() else { return }
+  //
+  //        if numberOfRows == 1 {
+  //            // 한 줄에 걸쳐있으면 하나만 생성
+  //            let raisedView = RaisedInfoView(title: title, infoType: infoType)
+  //            backViewMargin.addSubview(raisedView)
+  //            raisedView.snp.makeConstraints { make in
+  //                make.top.equalTo(headerStackView.snp.bottom).inset(
+  //                    isOverLapped ? -61 - (80 * (startDatePosition.row)) : -40 - (80 * (startDatePosition.row))
+  //                )
+  //                make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
+  //                make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
+  //                make.height.equalTo(17)
+  //            }
+  //
+  //        } else {
+  //            let firstRaisedView = RaisedInfoView(title: title, infoType: infoType)
+  //            backViewMargin.addSubview(firstRaisedView)
+  //            firstRaisedView.snp.makeConstraints { make in
+  //                make.top.equalTo(headerStackView.snp.bottom).inset(
+  //                    isOverLapped ? -61 - (80 * (startDatePosition.row)) : -40 - (80 * (startDatePosition.row))
+  //                )
+  //                make.leading.equalToSuperview().inset(widthInt * startDatePosition.column) // widthInt를 기준으로 *연산으로 inset값 정함
+  //                make.trailing.equalToSuperview().inset(0)
+  //                make.height.equalTo(17)
+  //            }
+  //
+  //            // 중간 뷰 그리기
+  //            if numberOfRows >= 3 {
+  //                for i in 1..<numberOfRows - 1 {
+  //                    let middleRaisedView = RaisedInfoView(title: title, infoType: infoType)
+  //                    backViewMargin.addSubview(middleRaisedView)
+  //                    middleRaisedView.snp.makeConstraints { make in
+  //                        make.top.equalTo(headerStackView.snp.bottom).inset(
+  //                            isOverLapped ? -61 - (80 * (startDatePosition.row + i)) : -40 - (80 * (startDatePosition.row + i))
+  //                        )
+  //                        make.leading.trailing.equalToSuperview().inset(0)
+  //                    }
+  //                }
+  //
+  //            }
+  //
+  //            let lastRaisedView = RaisedInfoView(title: title, infoType: infoType)
+  //            backViewMargin.addSubview(lastRaisedView)
+  //            lastRaisedView.snp.makeConstraints { make in
+  //                make.top.equalTo(headerStackView.snp.bottom).inset(
+  //                    isOverLapped ? -61 - (80 * (startDatePosition.row - 1)) : -40 - (80 * (startDatePosition.row - 1))
+  //                )
+  //                make.leading.equalToSuperview().inset(0)
+  //                make.trailing.equalToSuperview().inset(widthInt * (7 - endDatePosition.column - 1)) // 7 - widthInt
+  //                make.height.equalTo(17)
+  //            }
+  //        }
+  //    }
 
   // MARK: - Set up UI
   private func setupUI() {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
@@ -16,7 +16,6 @@ class RaisedInfoView: UIView {
     // 왼쪽 뷰
     var leftView: UIView = {
         let view = UIView()
-//        view.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1) // 이것도 두 가지로 바꿔
         return view
     }()
     
@@ -25,7 +24,6 @@ class RaisedInfoView: UIView {
         let lb = UILabel()
         lb.text = " "
         lb.font = BudgetBuddiesFontFamily.Pretendard.regular.font(size: 12)
-//        lb.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1) // 이것도 두 가지로 바꿔
         lb.setCharacterSpacing(-0.3)
         return lb
     }()
@@ -53,7 +51,7 @@ class RaisedInfoView: UIView {
             self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarYellow.color
             self.layer.borderColor = UIColor(red: 1, green: 0.83, blue: 0.44, alpha: 1).cgColor
             self.leftView.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1)
-            self.titleLabel.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1) // 이것도 두 가지로 바꿔
+            self.titleLabel.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1)
             
         case .support:
             self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarBlue.color

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
@@ -16,23 +16,25 @@ class RaisedInfoView: UIView {
     // 왼쪽 뷰
     var leftView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1)
+//        view.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1) // 이것도 두 가지로 바꿔
         return view
     }()
     
     // 타이틀
     var titleLabel: UILabel = {
         let lb = UILabel()
-        lb.text = "지그재그 썸머 세일"
+        lb.text = " "
         lb.font = BudgetBuddiesFontFamily.Pretendard.regular.font(size: 12)
-        lb.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1)
+//        lb.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1) // 이것도 두 가지로 바꿔
         lb.setCharacterSpacing(-0.3)
         return lb
     }()
     
     // MARK: - init
-    init(infoType: InfoType) {
+    init(title: String, infoType: InfoType) {
+        self.titleLabel.text = title
         self.infoType = infoType
+        
         super.init(frame: .zero)
         setupUI()
     }
@@ -46,15 +48,28 @@ class RaisedInfoView: UIView {
         self.addSubviews(leftView, titleLabel)
             
         // 배경
-        self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarYellow.color
+        switch infoType {
+        case .discount:
+            self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarYellow.color
+            self.layer.borderColor = UIColor(red: 1, green: 0.83, blue: 0.44, alpha: 1).cgColor
+            self.leftView.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1)
+            self.titleLabel.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1) // 이것도 두 가지로 바꿔
+            
+        case .support:
+            self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarBlue.color
+            self.layer.borderColor = UIColor(red: 0.33, green: 0.78, blue: 1, alpha: 1).cgColor
+            self.leftView.backgroundColor = BudgetBuddiesAsset.AppColor.coreBlue.color
+            self.titleLabel.textColor = UIColor(red: 0, green: 0.18, blue: 0.27, alpha: 1)
+            
+        }
         
         self.layer.borderWidth = 1.0
-        self.layer.borderColor = UIColor(red: 1, green: 0.83, blue: 0.44, alpha: 1).cgColor
         
         self.layer.masksToBounds = true
         self.layer.cornerRadius = 3
         
         setupConstraints()
+        
         
     }
     

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
@@ -1,0 +1,72 @@
+//
+//  RaisedInfoView.swift
+//  BudgetBuddies
+//
+//  Created by 김승원 on 7/30/24.
+//
+
+import UIKit
+import SnapKit
+
+class RaisedInfoView: UIView {
+    // MARK: - UI Components
+    // 왼쪽 뷰
+    var leftView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1)
+        return view
+    }()
+    
+    // 타이틀
+    var titleLabel: UILabel = {
+        let lb = UILabel()
+        lb.text = "지그재그 썸머 세일"
+        lb.font = BudgetBuddiesFontFamily.Pretendard.regular.font(size: 12)
+        lb.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1)
+        lb.setCharacterSpacing(-0.3)
+        return lb
+    }()
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Set up UI
+    private func setupUI() {
+        self.addSubviews(leftView, titleLabel)
+            
+        // 배경
+        self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarYellow.color
+        
+        self.layer.borderWidth = 1.0
+        self.layer.borderColor = UIColor(red: 1, green: 0.83, blue: 0.44, alpha: 1).cgColor
+        
+        self.layer.masksToBounds = true
+        self.layer.cornerRadius = 3
+        
+        setupConstraints()
+        
+    }
+    
+    // MARK: - Set up Constraints
+    private func setupConstraints() {
+        leftView.snp.makeConstraints { make in
+            make.leading.top.bottom.equalToSuperview()
+            make.width.equalTo(6)
+        }
+        
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(leftView.snp.trailing).offset(2)
+            make.trailing.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+            make.centerY.equalToSuperview()
+        }
+    }
+}

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
@@ -9,6 +9,9 @@ import UIKit
 import SnapKit
 
 class RaisedInfoView: UIView {
+    // MARK: - Properties
+    let infoType: InfoType
+    
     // MARK: - UI Components
     // 왼쪽 뷰
     var leftView: UIView = {
@@ -28,9 +31,9 @@ class RaisedInfoView: UIView {
     }()
     
     // MARK: - init
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
+    init(infoType: InfoType) {
+        self.infoType = infoType
+        super.init(frame: .zero)
         setupUI()
     }
     

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Views/RaisedInfoView.swift
@@ -5,84 +5,83 @@
 //  Created by 김승원 on 7/30/24.
 //
 
-import UIKit
 import SnapKit
+import UIKit
 
 class RaisedInfoView: UIView {
-    // MARK: - Properties
-    let infoType: InfoType
-    
-    // MARK: - UI Components
-    // 왼쪽 뷰
-    var leftView: UIView = {
-        let view = UIView()
-        return view
-    }()
-    
-    // 타이틀
-    var titleLabel: UILabel = {
-        let lb = UILabel()
-        lb.text = " "
-        lb.font = BudgetBuddiesFontFamily.Pretendard.regular.font(size: 12)
-        lb.setCharacterSpacing(-0.3)
-        return lb
-    }()
-    
-    // MARK: - init
-    init(title: String, infoType: InfoType) {
-        self.titleLabel.text = title
-        self.infoType = infoType
-        
-        super.init(frame: .zero)
-        setupUI()
+  // MARK: - Properties
+  let infoType: InfoType
+
+  // MARK: - UI Components
+  // 왼쪽 뷰
+  var leftView: UIView = {
+    let view = UIView()
+    return view
+  }()
+
+  // 타이틀
+  var titleLabel: UILabel = {
+    let lb = UILabel()
+    lb.text = " "
+    lb.font = BudgetBuddiesFontFamily.Pretendard.regular.font(size: 12)
+    lb.setCharacterSpacing(-0.3)
+    return lb
+  }()
+
+  // MARK: - init
+  init(title: String, infoType: InfoType) {
+    self.titleLabel.text = title
+    self.infoType = infoType
+
+    super.init(frame: .zero)
+    setupUI()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Set up UI
+  private func setupUI() {
+    self.addSubviews(leftView, titleLabel)
+
+    // 배경
+    switch infoType {
+    case .discount:
+      self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarYellow.color
+      self.layer.borderColor = UIColor(red: 1, green: 0.83, blue: 0.44, alpha: 1).cgColor
+      self.leftView.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1)
+      self.titleLabel.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1)
+
+    case .support:
+      self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarBlue.color
+      self.layer.borderColor = UIColor(red: 0.33, green: 0.78, blue: 1, alpha: 1).cgColor
+      self.leftView.backgroundColor = BudgetBuddiesAsset.AppColor.coreBlue.color
+      self.titleLabel.textColor = UIColor(red: 0, green: 0.18, blue: 0.27, alpha: 1)
+
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+
+    self.layer.borderWidth = 1.0
+
+    self.layer.masksToBounds = true
+    self.layer.cornerRadius = 3
+
+    setupConstraints()
+
+  }
+
+  // MARK: - Set up Constraints
+  private func setupConstraints() {
+    leftView.snp.makeConstraints { make in
+      make.leading.top.bottom.equalToSuperview()
+      make.width.equalTo(6)
     }
-    
-    // MARK: - Set up UI
-    private func setupUI() {
-        self.addSubviews(leftView, titleLabel)
-            
-        // 배경
-        switch infoType {
-        case .discount:
-            self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarYellow.color
-            self.layer.borderColor = UIColor(red: 1, green: 0.83, blue: 0.44, alpha: 1).cgColor
-            self.leftView.backgroundColor = UIColor(red: 1, green: 0.7, blue: 0, alpha: 1)
-            self.titleLabel.textColor = UIColor(red: 0.35, green: 0.15, blue: 0, alpha: 1)
-            
-        case .support:
-            self.backgroundColor = BudgetBuddiesAsset.AppColor.calendarBlue.color
-            self.layer.borderColor = UIColor(red: 0.33, green: 0.78, blue: 1, alpha: 1).cgColor
-            self.leftView.backgroundColor = BudgetBuddiesAsset.AppColor.coreBlue.color
-            self.titleLabel.textColor = UIColor(red: 0, green: 0.18, blue: 0.27, alpha: 1)
-            
-        }
-        
-        self.layer.borderWidth = 1.0
-        
-        self.layer.masksToBounds = true
-        self.layer.cornerRadius = 3
-        
-        setupConstraints()
-        
-        
+
+    titleLabel.snp.makeConstraints { make in
+      make.leading.equalTo(leftView.snp.trailing).offset(2)
+      make.trailing.equalToSuperview()
+      make.top.bottom.equalToSuperview()
+      make.centerY.equalToSuperview()
     }
-    
-    // MARK: - Set up Constraints
-    private func setupConstraints() {
-        leftView.snp.makeConstraints { make in
-            make.leading.top.bottom.equalToSuperview()
-            make.width.equalTo(6)
-        }
-        
-        titleLabel.snp.makeConstraints { make in
-            make.leading.equalTo(leftView.snp.trailing).offset(2)
-            make.trailing.equalToSuperview()
-            make.top.bottom.equalToSuperview()
-            make.centerY.equalToSuperview()
-        }
-    }
+  }
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
@@ -52,3 +52,66 @@ extension YearMonth {
     return numberOfWeeks > 5
   }
 }
+
+
+
+
+struct InfoModel {
+    let title: String?
+    let startDate: String?
+    let endDate: String?
+}
+
+extension InfoModel {
+    private func date(from dateString: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter.date(from: dateString)
+    }
+
+    private func startOfMonth(for date: Date) -> Int? {
+        let calendar = Calendar.current
+        var components = calendar.dateComponents([.year, .month], from: date)
+        components.day = 1
+        
+        guard let firstDayOfMonth = calendar.date(from: components) else { return nil }
+        return calendar.component(.weekday, from: firstDayOfMonth)
+    }
+    
+    private func numberOfDaysInMonth(for date: Date) -> Int? {
+        let calendar = Calendar.current
+        guard let range = calendar.range(of: .day, in: .month, for: date) else { return nil }
+        return range.count
+    }
+    
+    private func positionOfDate(for date: Date) -> (row: Int, column: Int)? {
+        guard let startDay = startOfMonth(for: date),
+              let numberOfDays = numberOfDaysInMonth(for: date) else {
+            return nil
+        }
+        
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        guard let day = components.day else { return nil }
+        
+        let startDayIndex = startDay - 1
+        let dayIndex = startDayIndex + (day - 1)
+        
+        let row = dayIndex / 7
+        let column = dayIndex % 7
+        
+        return (row, column)
+    }
+    
+    func startDatePosition() -> (row: Int, column: Int)? {
+        guard let startDateString = startDate,
+              let date = date(from: startDateString) else { return nil }
+        return positionOfDate(for: date)
+    }
+    
+    func endDatePosition() -> (row: Int, column: Int)? {
+        guard let endDateString = endDate,
+              let date = date(from: endDateString) else { return nil }
+        return positionOfDate(for: date)
+    }
+}

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
@@ -7,10 +7,13 @@
 
 import UIKit
 
+// 임시 모델을 계속 사용하다보니까 이 모델에 대한 의존성이 높아져서
+// 추후에 api연결할 때 제대로 구현하겠습니다!
 // 임시 모델
 struct YearMonth {
   let year: Int?
   let month: Int?
+//    let infoModels: [InfoModel] = []
 }
 
 extension YearMonth {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
@@ -54,12 +54,16 @@ extension YearMonth {
 }
 
 
-
+enum InfoType {
+    case discount
+    case support
+}
 
 struct InfoModel {
     let title: String?
     let startDate: String?
     let endDate: String?
+    let infoType: InfoType
 }
 
 extension InfoModel {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
@@ -103,15 +103,32 @@ extension InfoModel {
         return (row, column)
     }
     
+    // 기간의 시작하는 위치를 (row, column)형태로 반환하는 함수
     func startDatePosition() -> (row: Int, column: Int)? {
         guard let startDateString = startDate,
               let date = date(from: startDateString) else { return nil }
         return positionOfDate(for: date)
     }
     
+    // 기간의 끝나는 위치를 (row, column)형태로 반환하는 함수
     func endDatePosition() -> (row: Int, column: Int)? {
         guard let endDateString = endDate,
               let date = date(from: endDateString) else { return nil }
         return positionOfDate(for: date)
+    }
+    
+    // 일정이 캘린ㄹ더에서 몇줄에 걸쳐있는지 반환하는 함수
+    func numberOfRows() -> Int? {
+        guard let startDateString = startDate,
+              let endDateString = endDate,
+              let startDate = date(from: startDateString),
+              let endDate = date(from: endDateString) else { return nil }
+        
+        guard let startPosition = positionOfDate(for: startDate),
+              let endPosition = positionOfDate(for: endDate) else { return nil }
+        
+        // 시작 날짜와 끝나는 날짜가 위치한 줄을 계산
+        let numberOfRows = endPosition.row - startPosition.row + 1
+        return numberOfRows
     }
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/TempModel.swift
@@ -13,7 +13,7 @@ import UIKit
 struct YearMonth {
   let year: Int?
   let month: Int?
-//    let infoModels: [InfoModel] = []
+  //    let infoModels: [InfoModel] = []
 }
 
 extension YearMonth {
@@ -56,86 +56,90 @@ extension YearMonth {
   }
 }
 
-
 enum InfoType {
-    case discount
-    case support
+  case discount
+  case support
 }
 
 struct InfoModel {
-    let title: String?
-    let startDate: String?
-    let endDate: String?
-    let infoType: InfoType
+  let title: String?
+  let startDate: String?
+  let endDate: String?
+  let infoType: InfoType
 }
 
 extension InfoModel {
-    private func date(from dateString: String) -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        return dateFormatter.date(from: dateString)
+  private func date(from dateString: String) -> Date? {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    return dateFormatter.date(from: dateString)
+  }
+
+  private func startOfMonth(for date: Date) -> Int? {
+    let calendar = Calendar.current
+    var components = calendar.dateComponents([.year, .month], from: date)
+    components.day = 1
+
+    guard let firstDayOfMonth = calendar.date(from: components) else { return nil }
+    return calendar.component(.weekday, from: firstDayOfMonth)
+  }
+
+  private func numberOfDaysInMonth(for date: Date) -> Int? {
+    let calendar = Calendar.current
+    guard let range = calendar.range(of: .day, in: .month, for: date) else { return nil }
+    return range.count
+  }
+
+  private func positionOfDate(for date: Date) -> (row: Int, column: Int)? {
+    guard let startDay = startOfMonth(for: date),
+      let numberOfDays = numberOfDaysInMonth(for: date)
+    else {
+      return nil
     }
 
-    private func startOfMonth(for date: Date) -> Int? {
-        let calendar = Calendar.current
-        var components = calendar.dateComponents([.year, .month], from: date)
-        components.day = 1
-        
-        guard let firstDayOfMonth = calendar.date(from: components) else { return nil }
-        return calendar.component(.weekday, from: firstDayOfMonth)
-    }
-    
-    private func numberOfDaysInMonth(for date: Date) -> Int? {
-        let calendar = Calendar.current
-        guard let range = calendar.range(of: .day, in: .month, for: date) else { return nil }
-        return range.count
-    }
-    
-    private func positionOfDate(for date: Date) -> (row: Int, column: Int)? {
-        guard let startDay = startOfMonth(for: date),
-              let numberOfDays = numberOfDaysInMonth(for: date) else {
-            return nil
-        }
-        
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day], from: date)
-        guard let day = components.day else { return nil }
-        
-        let startDayIndex = startDay - 1
-        let dayIndex = startDayIndex + (day - 1)
-        
-        let row = dayIndex / 7
-        let column = dayIndex % 7
-        
-        return (row, column)
-    }
-    
-    // 기간의 시작하는 위치를 (row, column)형태로 반환하는 함수
-    func startDatePosition() -> (row: Int, column: Int)? {
-        guard let startDateString = startDate,
-              let date = date(from: startDateString) else { return nil }
-        return positionOfDate(for: date)
-    }
-    
-    // 기간의 끝나는 위치를 (row, column)형태로 반환하는 함수
-    func endDatePosition() -> (row: Int, column: Int)? {
-        guard let endDateString = endDate,
-              let date = date(from: endDateString) else { return nil }
-        return positionOfDate(for: date)
-    }
-    
-    // 일정이 캘린ㄹ더에서 몇줄에 걸쳐있는지 반환하는 함수
-    func numberOfRows() -> Int? {
-        guard let startDateString = startDate,
-              let endDateString = endDate,
-              let startDate = date(from: startDateString),
-              let endDate = date(from: endDateString) else { return nil }
-        
-        guard let startPosition = positionOfDate(for: startDate),
-              let endPosition = positionOfDate(for: endDate) else { return nil }
-        
-        // 시작 날짜와 끝나는 날짜가 위치한 줄을 계산
-        let numberOfRows = endPosition.row - startPosition.row + 1
-        return numberOfRows
-    }
+    let calendar = Calendar.current
+    let components = calendar.dateComponents([.year, .month, .day], from: date)
+    guard let day = components.day else { return nil }
+
+    let startDayIndex = startDay - 1
+    let dayIndex = startDayIndex + (day - 1)
+
+    let row = dayIndex / 7
+    let column = dayIndex % 7
+
+    return (row, column)
+  }
+
+  // 기간의 시작하는 위치를 (row, column)형태로 반환하는 함수
+  func startDatePosition() -> (row: Int, column: Int)? {
+    guard let startDateString = startDate,
+      let date = date(from: startDateString)
+    else { return nil }
+    return positionOfDate(for: date)
+  }
+
+  // 기간의 끝나는 위치를 (row, column)형태로 반환하는 함수
+  func endDatePosition() -> (row: Int, column: Int)? {
+    guard let endDateString = endDate,
+      let date = date(from: endDateString)
+    else { return nil }
+    return positionOfDate(for: date)
+  }
+
+  // 일정이 캘린ㄹ더에서 몇줄에 걸쳐있는지 반환하는 함수
+  func numberOfRows() -> Int? {
+    guard let startDateString = startDate,
+      let endDateString = endDate,
+      let startDate = date(from: startDateString),
+      let endDate = date(from: endDateString)
+    else { return nil }
+
+    guard let startPosition = positionOfDate(for: startDate),
+      let endPosition = positionOfDate(for: endDate)
+    else { return nil }
+
+    // 시작 날짜와 끝나는 날짜가 위치한 줄을 계산
+    let numberOfRows = endPosition.row - startPosition.row + 1
+    return numberOfRows
+  }
 }


### PR DESCRIPTION
# 🍎 빈주머니즈 iOS Pull Request

## ✏️ 개요

> 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요

> 구현된 사항
- 일정 날짜에 따라 올바른 위치에 뷰 올리기
- 일정이 2주 이상 걸쳐있을 경우 다음 줄에도 올바르게 표시
- 일정이 2개 겹쳐있을 경우, 일정 시작 날짜순으로 겹쳐지지 않게 아래로 내리기 구현
- 현재는 7월 기준으로만 구현이 되어있기 때문에 달력을 바꿔도 그대로 남아있게 해뒀습니다.

> 추가 구현해야할 사항
- 일정이 한 줄에 연달아 3개 이상 겹칠 경우 우선순위에 따라 내릴 뷰와 가만히 둘 뷰 구분하는 로직 (데모데이때 사용할 일정들 받아보고 구현이 필요한지 판단하겠습니다.)
- api연결시 특정 월에 일정들을 받아 알맞은 달력에 표시

## 🚨 변경사항

> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## ✅ Checklist

> 체크리스트를 작성해주세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] import 코드와 같은 불필요한 코드들을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
- [x] [Apple Swift-Format](https://github.com/swiftlang/swift-format)을 사용해서 코드 포맷을 정리했습니다.

## 📱 구현화면

> gif 혹은 스크린샷 첨부해주세요!
<img width="502" alt="스크린샷 2024-08-01 오후 1 47 04" src="https://github.com/user-attachments/assets/91005178-4497-4c42-b6ed-de9b5907fc02">

## 🛠️ [issue](https://github.com/BudgetBuddiesTeam/FrontEnd/issues) 연결

- Resolved : #46 
