### PR TITLE
[Feat & Refactor] AllLookingVC -> InfoListVC, 주머니 캘린더(CalendarVC)로 이동하는 부분 수정

### DIFF
--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
@@ -139,7 +139,13 @@ class AllLookingViewController: UIViewController {
 
   @objc private func pocketCalendarContainerTapped() {
     debugPrint("주머니 캘린더")
-    navigationController?.pushViewController(calendarViewController, animated: true)
+//    navigationController?.pushViewController(calendarViewController, animated: true)
+      if let tabBarController = self.tabBarController as? RootTabBarViewController {
+          tabBarController.selectedIndex = 2
+          
+          // 노티로 시점 전달 (CalendarViewController에게)
+          NotificationCenter.default.post(name: NSNotification.Name("AllLookingToCalendar"), object: nil)
+      }
   }
 
   @objc private func priceEventInfoContainerTapped() {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
@@ -149,10 +149,12 @@ class AllLookingViewController: UIViewController {
   @objc private func priceEventInfoContainerTapped() {
     debugPrint("이번 달 할인정보 확인하기")
     navigationController?.pushViewController(discountInfoListViewController, animated: true)
+      discountInfoListViewController.yearMonth = YearMonth.setNowYearMonth()
   }
 
   @objc private func supportInfoConfirmContainerTapped() {
     debugPrint("이번 달 지원정보 확인하기")
     navigationController?.pushViewController(supportInfoListViewController, animated: true)
+      supportInfoListViewController.yearMonth = YearMonth.setNowYearMonth()
   }
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
@@ -149,12 +149,12 @@ class AllLookingViewController: UIViewController {
   @objc private func priceEventInfoContainerTapped() {
     debugPrint("이번 달 할인정보 확인하기")
     navigationController?.pushViewController(discountInfoListViewController, animated: true)
-      discountInfoListViewController.yearMonth = YearMonth.setNowYearMonth()
+    discountInfoListViewController.yearMonth = YearMonth.setNowYearMonth()
   }
 
   @objc private func supportInfoConfirmContainerTapped() {
     debugPrint("이번 달 지원정보 확인하기")
     navigationController?.pushViewController(supportInfoListViewController, animated: true)
-      supportInfoListViewController.yearMonth = YearMonth.setNowYearMonth()
+    supportInfoListViewController.yearMonth = YearMonth.setNowYearMonth()
   }
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
@@ -139,13 +139,14 @@ class AllLookingViewController: UIViewController {
 
   @objc private func pocketCalendarContainerTapped() {
     debugPrint("주머니 캘린더")
-//    navigationController?.pushViewController(calendarViewController, animated: true)
-      if let tabBarController = self.tabBarController as? RootTabBarViewController {
-          tabBarController.selectedIndex = 2
-          
-          // 노티로 시점 전달 (CalendarViewController에게)
-          NotificationCenter.default.post(name: NSNotification.Name("AllLookingToCalendar"), object: nil)
-      }
+    //    navigationController?.pushViewController(calendarViewController, animated: true)
+    if let tabBarController = self.tabBarController as? RootTabBarViewController {
+      tabBarController.selectedIndex = 2
+
+      // 노티로 시점 전달 (CalendarViewController에게)
+      NotificationCenter.default.post(
+        name: NSNotification.Name("AllLookingToCalendar"), object: nil)
+    }
   }
 
   @objc private func priceEventInfoContainerTapped() {

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
@@ -142,10 +142,6 @@ class AllLookingViewController: UIViewController {
     navigationController?.pushViewController(calendarViewController, animated: true)
   }
 
-  /*
-   해야 할 일
-   - 아무것도 화면에 나타나지 않는 "할인정보" & "지원정보" ViewController를 연결하기
-   */
   @objc private func priceEventInfoContainerTapped() {
     debugPrint("이번 달 할인정보 확인하기")
     navigationController?.pushViewController(discountInfoListViewController, animated: true)

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
@@ -39,7 +39,7 @@ final class CalendarViewController: UIViewController {
     setupTableViews()
     setupButtonActions()
     setupNavigationBar()
-      setupNotificationCenterObservers()
+    setupNotificationCenterObservers()
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -47,20 +47,26 @@ final class CalendarViewController: UIViewController {
 
     setupNavigationBar()
   }
-    
-    deinit {
-        // 노티 remove (메모리 누수 방지)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("MainToCalendar"), object: nil)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("AllLookingToCalendar"), object: nil)
-    }
-    
-    // MARK: - Set up NotificationCenterObservers
-    // 노티 등록
-    private func setupNotificationCenterObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(switchToCalendarHandler), name: NSNotification.Name("MainToCalendar"), object: nil)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(switchToCalendarHandler), name: NSNotification.Name("AllLookingToCalendar"), object: nil)
-    }
+
+  deinit {
+    // 노티 remove (메모리 누수 방지)
+    NotificationCenter.default.removeObserver(
+      self, name: NSNotification.Name("MainToCalendar"), object: nil)
+    NotificationCenter.default.removeObserver(
+      self, name: NSNotification.Name("AllLookingToCalendar"), object: nil)
+  }
+
+  // MARK: - Set up NotificationCenterObservers
+  // 노티 등록
+  private func setupNotificationCenterObservers() {
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(switchToCalendarHandler),
+      name: NSNotification.Name("MainToCalendar"), object: nil)
+
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(switchToCalendarHandler),
+      name: NSNotification.Name("AllLookingToCalendar"), object: nil)
+  }
 
   // MARK: - Set up Now YearMonth
   func setupNowYearMonth() {
@@ -201,11 +207,11 @@ final class CalendarViewController: UIViewController {
     vc.delegate = self
     self.present(vc, animated: true, completion: nil)
   }
-    
-    @objc
-    private func switchToCalendarHandler() {
-        setupNowYearMonth()
-    }
+
+  @objc
+  private func switchToCalendarHandler() {
+    setupNowYearMonth()
+  }
 }
 
 // MARK: - UITableView DataSource

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class CalendarViewController: UIViewController {
+final class CalendarViewController: UIViewController {
   // MARK: - Properties
   var yearMonth: YearMonth? {
     didSet {
@@ -39,6 +39,7 @@ class CalendarViewController: UIViewController {
     setupTableViews()
     setupButtonActions()
     setupNavigationBar()
+      setupNotificationCenterObservers()
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -46,11 +47,24 @@ class CalendarViewController: UIViewController {
 
     setupNavigationBar()
   }
+    
+    deinit {
+        // 노티 remove (메모리 누수 방지)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("MainToCalendar"), object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("AllLookingToCalendar"), object: nil)
+    }
+    
+    // MARK: - Set up NotificationCenterObservers
+    // 노티 등록
+    private func setupNotificationCenterObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(switchToCalendarHandler), name: NSNotification.Name("MainToCalendar"), object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(switchToCalendarHandler), name: NSNotification.Name("AllLookingToCalendar"), object: nil)
+    }
 
   // MARK: - Set up Now YearMonth
-  private func setupNowYearMonth() {
+  func setupNowYearMonth() {
     self.yearMonth = YearMonth.setNowYearMonth()
-
   }
 
   // MARK: - Set up Data
@@ -187,6 +201,11 @@ class CalendarViewController: UIViewController {
     vc.delegate = self
     self.present(vc, animated: true, completion: nil)
   }
+    
+    @objc
+    private func switchToCalendarHandler() {
+        setupNowYearMonth()
+    }
 }
 
 // MARK: - UITableView DataSource

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Main/MainViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Main/MainViewController.swift
@@ -128,8 +128,14 @@ extension MainViewController {
 
   // "N월 주머니 정보" 옆에 있는 "전체보기 >" 버튼
   @objc private func budgetInfoLookEntireButtonContainerTapped() {
-    let calendarViewController = CalendarViewController()
-    navigationController?.pushViewController(calendarViewController, animated: true)
+//    let calendarViewController = CalendarViewController()
+//    navigationController?.pushViewController(calendarViewController, animated: true)
+      if let tabBarController = self.tabBarController as? RootTabBarViewController {
+          tabBarController.selectedIndex = 2
+          
+          // 노티로 시점 전달 (CalendarViewController에게)
+          NotificationCenter.default.post(name: NSNotification.Name("MainToCalendar"), object: nil)
+      }
   }
 
   // "N월 소비 분석" 옆에 있는 "전체보기 >" 버튼

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Main/MainViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Main/MainViewController.swift
@@ -128,14 +128,14 @@ extension MainViewController {
 
   // "N월 주머니 정보" 옆에 있는 "전체보기 >" 버튼
   @objc private func budgetInfoLookEntireButtonContainerTapped() {
-//    let calendarViewController = CalendarViewController()
-//    navigationController?.pushViewController(calendarViewController, animated: true)
-      if let tabBarController = self.tabBarController as? RootTabBarViewController {
-          tabBarController.selectedIndex = 2
-          
-          // 노티로 시점 전달 (CalendarViewController에게)
-          NotificationCenter.default.post(name: NSNotification.Name("MainToCalendar"), object: nil)
-      }
+    //    let calendarViewController = CalendarViewController()
+    //    navigationController?.pushViewController(calendarViewController, animated: true)
+    if let tabBarController = self.tabBarController as? RootTabBarViewController {
+      tabBarController.selectedIndex = 2
+
+      // 노티로 시점 전달 (CalendarViewController에게)
+      NotificationCenter.default.post(name: NSNotification.Name("MainToCalendar"), object: nil)
+    }
   }
 
   // "N월 소비 분석" 옆에 있는 "전체보기 >" 버튼


### PR DESCRIPTION
# 🍎 빈주머니즈 iOS Pull Request

## ✏️ 개요

> 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요

- AllLookingVC에서 이번 달 할인, 지원정보 탭 했을 때 이동 구현
- 현재 시간 기준으로 데이터 받아오도록 구현
- MainVC, AllLookingVC에서 CalendarVC로 이동하는 부분 수정

> 구체적인 수정 사항

- 기존 pushViewController()방식을 tabBarController의 selectedIndex를 바꿔 이동하는 방식으로 수정
- tabBar로 VC를 이동하면서 현재 시간 기준의 주머니 캘린더를 볼 수 있도록 NotificationCenter를 이용하여 구현

> 수정 이유

- pushViewController로 진행할 경우 CalendarVC컴포넌트를 여러 곳에서 불필요하게 더 만들음!
- CalendarVC에 NavigationVar가 isHidden=true상태이기 때문에 이 이전에 VC가 존재하게 되면 다음 VC(InfoListVC)로 넘어갈 때 네비가 깜빡 거리면서 겹치는 오류가 생김!!


## 🚨 변경사항

> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## ✅ Checklist

> 체크리스트를 작성해주세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] import 코드와 같은 불필요한 코드들을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.
- [x] [Apple Swift-Format](https://github.com/swiftlang/swift-format)을 사용해서 코드 포맷을 정리했습니다.

## 📱 구현화면

> gif 혹은 스크린샷 첨부해주세요!

메인페이지에 8월 주머니 정보 전체보기 & 전체페이지에서 주머니 캘린더 들을 탭할 경우 탭바로 움직는 것을 확인하시면 됩니다!

https://github.com/user-attachments/assets/0a53cfb1-1878-4ba9-add5-a39caaf4e16a

https://github.com/user-attachments/assets/fdc49b53-1458-47bd-8dd6-f23e43691c7c




## 🛠️ [issue](https://github.com/BudgetBuddiesTeam/FrontEnd/issues) 연결

- Resolved : #108 
