### PR TITLE
[Refactor] 메인화면 데이터가 로딩되는 시간 연장하는 UX 설계 #140

### DIFF
--- a/BudgetBuddies/BudgetBuddies/Sources/SceneDelegate.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = (scene as? UIWindowScene) else { return }
     window = UIWindow(frame: UIScreen.main.bounds)
     window?.windowScene = windowScene
-    window?.rootViewController = RootTabBarController()
+    window?.rootViewController = ExtendedLaunchScreenViewController()
     window?.makeKeyAndVisible()
   }
 

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AccountBook/Consume/ConsumeViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AccountBook/Consume/ConsumeViewController.swift
@@ -149,7 +149,7 @@ extension ConsumeViewController {
     let amount = Int(self.writtenConsumedPriceText) ?? 0
     let description = self.writtenConsumedContentText
     let expenseDate: String
-   
+
     /*
      해야 할 일
      - 모델 객체에서 날짜를 저장하는 형식을 문자열로 보관
@@ -193,11 +193,11 @@ extension ConsumeViewController {
       case .success:
         let postSuccessAlertController = UIAlertController(
           title: "알림", message: "새로운 소비 내역을 추가했습니다", preferredStyle: .alert)
-        let confirmedButtonAction = UIAlertAction(title: "확인", style: .default) { [weak self]_ in
+        let confirmedButtonAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
           self?.consumeView.consumedPriceTextField.text = String()
           self?.consumeView.consumedContentTextField.text = String()
           self?.consumeView.consumedDatePicker.date = Date()
-          
+
           /*
            설명
            - 카테고리 선택 버튼은 CategorySelectTableViewController의 모델 객체의 데이터를 추종하는 성격이 있습니다.

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/AllLooking/AllLookingViewController.swift
@@ -184,7 +184,7 @@ extension AllLookingViewController {
 // MARK: - Network
 
 extension AllLookingViewController {
-  private func fetchUserData(userId: Int) {
+  public func fetchUserData(userId: Int) {
     provider.request(.find(userId: userId)) { result in
       switch result {
       case .success(let response):

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Calendar/Calendar/Controllers/CalendarViewController.swift
@@ -86,7 +86,9 @@ final class CalendarViewController: UIViewController {
   }
 
   // MARK: - Set up Data
-  private func setupData() {
+
+  /// 캘린더의 데이터를 가져오는 메소드입니다.
+  public func setupData() {
     print("-----------캘린더 메인 fetch-----------")
     guard let yearMonth = self.yearMonth else { return }
 

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/CustomTabBar/Controllers/RootTabBarController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/CustomTabBar/Controllers/RootTabBarController.swift
@@ -9,13 +9,40 @@ import UIKit
 
 class RootTabBarController: CustomTabBarController {
   // MARK: - Properties
-  private let mainViewController = UINavigationController(rootViewController: MainViewController())
-  private let consumeViewController = UINavigationController(
-    rootViewController: ConsumeViewController())
-  private let calendarViewController = UINavigationController(
-    rootViewController: CalendarViewController())
-  private let allLookingViewController = UINavigationController(
-    rootViewController: AllLookingViewController())
+
+  // Controller
+
+  public let mainViewController: MainViewController!
+  public let consumeViewController: ConsumeViewController!
+  public let calendarViewController: CalendarViewController!
+  public let allLookingViewController: AllLookingViewController!
+
+  private let mainViewNavigationController: UINavigationController!
+  private let consumeViewNavigationController: UINavigationController!
+  private let calendarViewNavigationController: UINavigationController!
+  private let allLookingViewNavigationController: UINavigationController!
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+
+    mainViewController = MainViewController()
+    consumeViewController = ConsumeViewController()
+    calendarViewController = CalendarViewController()
+    allLookingViewController = AllLookingViewController()
+
+    mainViewNavigationController = UINavigationController(rootViewController: mainViewController)
+    consumeViewNavigationController = UINavigationController(
+      rootViewController: consumeViewController)
+    calendarViewNavigationController = UINavigationController(
+      rootViewController: calendarViewController)
+    allLookingViewNavigationController = UINavigationController(
+      rootViewController: allLookingViewController)
+
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 
   // MARK: - Life Cycle
   override func viewDidLoad() {
@@ -29,10 +56,10 @@ class RootTabBarController: CustomTabBarController {
     self.view.backgroundColor = BudgetBuddiesAsset.AppColor.background.color
 
     self.setupViewControllers([
-      mainViewController,
-      consumeViewController,
-      calendarViewController,
-      allLookingViewController,
+      mainViewNavigationController,
+      consumeViewNavigationController,
+      calendarViewNavigationController,
+      allLookingViewNavigationController,
     ])
   }
 }

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/ExtendedLaunchScreen/ExtendedLaunchScreenView.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/ExtendedLaunchScreen/ExtendedLaunchScreenView.swift
@@ -1,0 +1,45 @@
+//
+//  ExtendedLaunchScreenView.swift
+//  BudgetBuddies
+//
+//  Created by Jiwoong CHOI on 8/23/24.
+//
+
+import SnapKit
+import UIKit
+
+class ExtendedLaunchScreenView: UIView {
+  // MARK: - Properties
+
+  private let budgetBuddiesLogo: UIImageView = {
+    let imageView = UIImageView()
+    imageView.image = BudgetBuddiesAsset.AppImage.Logo.logoImage.image
+    return imageView
+  }()
+
+  // MARK: - Initializer
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    setLayout()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Methods
+
+  private func setLayout() {
+    self.backgroundColor = BudgetBuddiesAsset.AppColor.coreYellow.color
+
+    self.addSubview(budgetBuddiesLogo)
+    budgetBuddiesLogo.snp.makeConstraints { make in
+      make.width.equalTo(116)
+      make.height.equalTo(108)
+      make.top.equalTo(safeAreaLayoutGuide.snp.top).inset(261)
+      make.centerX.equalToSuperview()
+    }
+  }
+}

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/ExtendedLaunchScreen/ExtendedLaunchScreenViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/ExtendedLaunchScreen/ExtendedLaunchScreenViewController.swift
@@ -1,0 +1,56 @@
+//
+//  ExtendedLaunchScreenViewController.swift
+//  BudgetBuddies
+//
+//  Created by Jiwoong CHOI on 8/23/24.
+//
+
+import UIKit
+
+class ExtendedLaunchScreenViewController: UIViewController {
+
+  // MARK: - Properties
+
+  // View Properties
+  private let extendedLaunchScreenView = ExtendedLaunchScreenView()
+
+  // Controller Properties
+  private let rootTabBarController = RootTabBarController()
+
+  // Variable Properties
+  private let userId = 1
+
+  // MARK: - View Life Cycle
+
+  override func loadView() {
+    view = extendedLaunchScreenView
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    self.fetchMainModelData()
+    Thread.sleep(forTimeInterval: 3)
+    self.connectRootTabBarController()
+  }
+
+  // MARK: - Methods
+
+  private func fetchMainModelData() {
+    self.rootTabBarController.mainViewController.fetchUserDataFromServer(userId: self.userId)
+    self.rootTabBarController.mainViewController.fetchDataFromMainPageAPI(userId: self.userId)
+    self.rootTabBarController.calendarViewController.setupData()
+    self.rootTabBarController.allLookingViewController.fetchUserData(userId: self.userId)
+  }
+
+  private func connectRootTabBarController() {
+    if let window = view.window {
+      UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
+        window.rootViewController = self.rootTabBarController
+      }
+    }
+  }
+}

--- a/BudgetBuddies/BudgetBuddies/Sources/Screen/Main/MainViewController.swift
+++ b/BudgetBuddies/BudgetBuddies/Sources/Screen/Main/MainViewController.swift
@@ -261,7 +261,7 @@ extension MainViewController {
 
 extension MainViewController {
 
-  private func fetchUserDataFromServer(userId: Int) {
+  public func fetchUserDataFromServer(userId: Int) {
     userRouterProvider.request(.find(userId: self.userId)) { result in
       switch result {
       case .success(let response):
@@ -282,7 +282,7 @@ extension MainViewController {
   ///
   /// # 설명
   /// - 메인화면에서 보여지는 데이터들을 가져오기 위해서 사용합니다.
-  private func fetchDataFromMainPageAPI(userId: Int) {
+  public func fetchDataFromMainPageAPI(userId: Int) {
     mainRouterProvider.request(.get(userId: userId)) { result in
       switch result {
       case let .success(moyaResponse):


### PR DESCRIPTION
# 🍎 빈주머니즈 iOS Pull Request

## ✏️ 개요

> 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요

- `ExtendedLaunchScreenController`를 추가해서 데이터를 미리 불러와 다른 화면들이 로드되기 전에 데이터들을 **pre-fetch** 합니다.
- LaunchScreen이 보다 오래되도록 설정해두었습니다.

## 🚨 변경사항

> 어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## ✅ Checklist

> 체크리스트를 작성해주세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.
- [X] import 코드와 같은 불필요한 코드들을 삭제했습니다.
- [X] 기존의 코드에 영향이 없는 것을 확인했습니다.
- [X] [Apple Swift-Format](https://github.com/swiftlang/swift-format)을 사용해서 코드 포맷을 정리했습니다.

## 📱 구현화면

> gif 혹은 스크린샷 첨부해주세요!

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-23 at 11 36 27](https://github.com/user-attachments/assets/9ecf7ae4-aad7-457d-8e8b-b35c22fc1b1c)


## 🛠️ [issue](https://github.com/BudgetBuddiesTeam/FrontEnd/issues) 연결

- Resolved : #140
